### PR TITLE
Extension method to set complete buttons states for Xbox360Report

### DIFF
--- a/ViGEmClient/Targets/Xbox360/Xbox360ReportExtensions.cs
+++ b/ViGEmClient/Targets/Xbox360/Xbox360ReportExtensions.cs
@@ -12,6 +12,11 @@ namespace Nefarius.ViGEm.Client.Targets.Xbox360
             }
         }
 
+        public static void SetButtonsFull(this Xbox360Report report, Xbox360Buttons buttons)
+        {
+            report.Buttons = (ushort)buttons;
+        }
+
         public static void SetButtonState(this Xbox360Report report, Xbox360Buttons button, bool state)
         {
             if (state)


### PR DESCRIPTION
This minor change adds a new extension method to Xbox360ReportExtensions that sets the complete state of all buttons in an Xbox360Report. Although the Buttons property setter is now public, DS4Windows seemed to work better when using a method to set the button state as opposed to using the property setter in this case.