### PR TITLE
Take UserData argument for notification callback into account

### DIFF
--- a/ViGEmClient/Targets/DualShock4Controller.cs
+++ b/ViGEmClient/Targets/DualShock4Controller.cs
@@ -86,7 +86,7 @@ namespace Nefarius.ViGEm.Client.Targets
             //
             // Callback to event
             // 
-            _notificationCallback = (client, target, motor, smallMotor, color) => FeedbackReceived?.Invoke(this,
+            _notificationCallback = (client, target, motor, smallMotor, color, userData) => FeedbackReceived?.Invoke(this,
                 new DualShock4FeedbackReceivedEventArgs(motor, smallMotor,
                     new LightbarColor(color.Red, color.Green, color.Blue)));
 

--- a/ViGEmClient/Targets/Xbox360Controller.cs
+++ b/ViGEmClient/Targets/Xbox360Controller.cs
@@ -85,7 +85,7 @@ namespace Nefarius.ViGEm.Client.Targets
             //
             // Callback to event
             // 
-            _notificationCallback = (client, target, largeMotor, smallMotor, number) =>
+            _notificationCallback = (client, target, largeMotor, smallMotor, number, userData) =>
             {
                 UserIndex = number;
 

--- a/ViGEmClient/ViGEmClient.Native.cs
+++ b/ViGEmClient/ViGEmClient.Native.cs
@@ -7,6 +7,7 @@ namespace Nefarius.ViGEm.Client
     using PVIGEM_CLIENT = IntPtr;
     using PVIGEM_TARGET = IntPtr;
     using PVIGEM_TARGET_ADD_RESULT = IntPtr;
+    using PVIGEM_USER_DATA = IntPtr;
 
     [SuppressUnmanagedCodeSecurity]
     partial class ViGEmClient
@@ -97,7 +98,8 @@ namespace Nefarius.ViGEm.Client
             PVIGEM_TARGET Target,
             byte LargeMotor,
             byte SmallMotor,
-            byte LedNumber);
+            byte LedNumber,
+            PVIGEM_USER_DATA UserData);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         internal delegate void PVIGEM_DS4_NOTIFICATION(
@@ -105,7 +107,8 @@ namespace Nefarius.ViGEm.Client
             PVIGEM_TARGET Target,
             byte LargeMotor,
             byte SmallMotor,
-            DS4_LIGHTBAR_COLOR LightbarColor);
+            DS4_LIGHTBAR_COLOR LightbarColor,
+            PVIGEM_USER_DATA UserData);
 
         [DllImport("vigemclient.dll", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         static extern PVIGEM_CLIENT vigem_alloc();


### PR DESCRIPTION
Stumbled upon an issue with feedback calls failing while testing vibration. Found an issue that would regularly happen after the notification callback was finished executing. A mismatch of function arguments between the C++ and C# side was happening because the .NET library was never updated to take the passed UserData instance into account. That oversight would lead to crashing in many cases when compiled for x86 arch. These changes fix the problem.

Here is the most prevalent error that was popping up in Debug mode.

> Run-Time Check Failure #0 - The value of ESP was not properly saved across a function call. This is usually a result of calling a function declared with one calling convention with a function pointer declared with a different calling convention.

